### PR TITLE
Fixing 1.1 sounds

### DIFF
--- a/src/main/java/org/itxtech/synapseapi/SynapsePlayer11.java
+++ b/src/main/java/org/itxtech/synapseapi/SynapsePlayer11.java
@@ -1844,6 +1844,7 @@ public class SynapsePlayer11 extends SynapsePlayer {
 
                             if (stackPacket.resourcePackStack.length == 0) {
                                 if (preLoginEventTask.isFinished()) {
+                                    this.dataPacket(stackPacket);
                                     this.processLogin();
                                 } else {
                                     this.shouldLogin = true;


### PR DESCRIPTION
This pull fixes the 1.1 sounds, makes them playable.
Basic logic: the Minecraft 1.1 client waiting for stack packet by server. If the stack packet hasn't been sent, it just doesnt loading basic sounds (ambient, blocks, etc.), thats why you can't hear them in-game. My pull makes SynapseAPI to send this packet, so client knows, if the server has 0 resource packs, and starting loading the default resource pack, which contains those sounds.

P.S. Sorry, if my english is bad